### PR TITLE
Add timezone support for sprint generation.

### DIFF
--- a/src/sprint/services/sprint.coffee
+++ b/src/sprint/services/sprint.coffee
@@ -7,7 +7,7 @@ angular.module 'Scrumble.sprint'
     endM = moment(end).add(1, 'days')
     return unless endM.isAfter current
     days = []
-    while not current.isSame endM
+    while not current.isSame endM, 'day'
       day = current.isoWeekday()
       if day isnt 6 and day isnt 7
         days.push {

--- a/src/sprint/services/sprint.test.coffee
+++ b/src/sprint/services/sprint.test.coffee
@@ -49,6 +49,14 @@ describe 'sprintUtils', ->
       expect(dates).toContain '2015-12-22'
       expect(dates).toContain '2015-12-23'
 
+    it 'should handle different timezones', ->
+      sprint =
+        dates:
+          start: '2016-05-09T23:00:00'
+          end: '2016-05-12T22:00:00'
+        resources: {}
+      @sprintUtils.ensureDataConsistency 'date', sprint, []
+
   describe 'generateResources', ->
     it 'should return undefined if an input is undefined', ->
       sprint =


### PR DESCRIPTION
Fixes a bug where the application would run into an infinite loop because of a timezone difference.

This fix compares only the day and not the hours, minutes and seconds when generating the list of days in a sprint.