### PR TITLE
Fix sprint widget perfect displayed as Failed

### DIFF
--- a/src/sprint/services/sprint.coffee
+++ b/src/sprint/services/sprint.coffee
@@ -93,7 +93,7 @@ angular.module 'Scrumble.sprint'
     return unless _.isArray sprint?.bdcData
     [first, ..., last] = sprint.bdcData
     if _.isNumber last.done
-      return if last.done > last.standard then 'ok' else 'ko'
+      return if last.done >= last.standard then 'ok' else 'ko'
     else
       return 'unknown'
   # return true if done > standard, false if done < standard, undefined otherwise


### PR DESCRIPTION
When you manage to do exactly what you where aiming to
for instance 35pts when your full sprint is 35pts, your sprint
is displayed as failed.

That is really sad and thus this commit fix this by making ok
a sprint perfectly done.