### PR TITLE
Redirect to https onload

### DIFF
--- a/src/index.jade
+++ b/src/index.jade
@@ -8,6 +8,10 @@ html(lang="en", ng-app="Scrumble")
     link(rel="stylesheet" href="css/vendor.css")
     link(rel="stylesheet" href="css/app.css")
     link(rel="icon", type="image/x-icon", href="images/favicon.ico")
+    script.
+      if (window.location.host.match(/^\w+.github.io$/g) && window.location.protocol != "https:"){
+      window.location.protocol = "https";
+      }
   body
     md-content.grey-background(ui-view layout="column")
     script(src='js/please-wait.min.js')


### PR DESCRIPTION
This fixes #129 

This redirect the github.io site onload to https.
This does not redirect localhost or 127.0.0.1 to htpps (praise the dev).

Caution : this will make informations stored on the http://scrumble.github.io localstorage unavalable
So far I only found that it marks as unread the "What's new in scrumble" content.