### PR TITLE
Change "Sign Up" button to "Sign In with Trello".

### DIFF
--- a/showcase/public/index.html
+++ b/showcase/public/index.html
@@ -33,7 +33,7 @@
 					<header id="header" class="alt">
 						<h1><a href="index.html">Scrumble</a></h1>
 						<nav>
-							<a href="https://app.scrumble.io">Sign Up</a>
+							<a href="https://app.scrumble.io">Sign In with Trello</a>
 						</nav>
 					</header>
 


### PR DESCRIPTION
Feedback from English users here in London: "The 'Sign Up' annoys me cause you don't really sign-up, I wish it was 'Sign In'."
So here it is, I replaced the "Sign Up" button with "Sign In with Trello" to make it clearer what's going to happen.