### PR TITLE
Fix bower deps (fix #206)

### DIFF
--- a/client/bower.json
+++ b/client/bower.json
@@ -43,9 +43,9 @@
     "lodash": "4.13.1",
     "angular-date-interceptor": "1.0.0",
     "angular-google-gapi": "1.0.0-beta.2",
-    "highcharts": "~5.0.6"
+    "highcharts": "5.0.6"
   },
   "resolutions": {
-    "angular": "1.5.8"
+    "angular": "~1.5.8"
   }
 }


### PR DESCRIPTION
This fixes `make install` somehow.

In the future, we should move bower deps to npm, and use a yarn.lock...