### PR TITLE
Compare values with a 1-digit precision

### DIFF
--- a/client/src/sprint/services/sprint.coffee
+++ b/client/src/sprint/services/sprint.coffee
@@ -93,7 +93,7 @@ angular.module 'Scrumble.sprint'
     return unless _.isArray sprint?.bdcData
     [first, ..., last] = sprint.bdcData
     if _.isNumber last.done
-      return if last.done >= last.standard then 'ok' else 'ko'
+      return if last.done.toFixed(1) >= last.standard.toFixed(1) then 'ok' else 'ko'
     else
       return 'unknown'
   # return true if done > standard, false if done < standard, undefined otherwise


### PR DESCRIPTION
This should avoid false results due to differences smaller then 0.1 point