### PR TITLE
Add extra day calculation in report-builder and add VPTech + watcher role

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ For Mac OS X users, the project folder must be in a subfolder of /Users, due to 
 make install
 ```
 
+**Launch the project**
+
+```
+make start
+```
+
 The project will be available at `http://0.0.0.0:8083/`
 
 If the app is stuck in the loading screen (with the Scrumble logo), go to this file :
@@ -66,12 +72,6 @@ angular.module 'Scrumble.login'
 ```
 
 DO NOT COMMIT THIS FILE
-
-**Launch the project**
-
-```
-make start
-```
 
 ## Provisioning
 

--- a/client/src/daily-report/services/report-builder.coffee
+++ b/client/src/daily-report/services/report-builder.coffee
@@ -55,10 +55,32 @@ angular.module 'Scrumble.daily-report'
         return false
 
       if sprint?.dates?.end
-        if moment().diff(sprint.dates.end, 'days') < -2 # End of sprint is in more than 2 days
+        extraDay = if isLastDayAFullDay(sprint.resources.matrix) then -1 else 0
+        if (moment().diff(sprint.dates.end, 'days') + extraDay) <= -2 # End of sprint is in more than 2 days
           return false
-      return true
 
+      return true
+    return false
+
+  # The last day in Scrumble might not be the day of the ceremony.
+  # 
+  # Case 1 : Ceremony is Friday at 9am
+  # Team sets Thursday as the last day but Thursday is a full day of code.
+  # returns true
+  #
+  # Case 2 : Ceremony is Friday at 11am
+  # Team sets Friday as the last day but Friday is not a full day (only 2hours of code).
+  # returns false
+  #
+  # How it works ?
+  # Check if capacity of the team during the last day is over 0.5
+  isLastDayAFullDay = (matrix) ->
+    [..., lastDayCapacities] = matrix
+    # For the last day not to be a full day, every member must have a capacity <= 0.5
+    for capacity in lastDayCapacities
+      if capacity > 0.5
+        return true
+    return false
 
   _svg = null
   dynamicFieldsPromise = null

--- a/client/src/project/services/projectUtils.coffee
+++ b/client/src/project/services/projectUtils.coffee
@@ -8,6 +8,9 @@ angular.module 'Scrumble.settings'
     label: 'Architect Developer'
     value: 'archi'
   ,
+    label: 'VP Tech'
+    value: 'vptech'
+  ,
     label: 'Product Owner'
     value: 'PO'
   ,
@@ -33,6 +36,9 @@ angular.module 'Scrumble.settings'
     ,
       label: 'to'
       value: 'to'
+    ,
+      label: 'watcher'
+      value: 'watcher'
     ,
     ]
   getRoles: -> roles


### PR DESCRIPTION
### Add extra day calculation in report-builder

Implement PR #256 functionnalities (start from `fix-daily-copty-cto-days` branch)

The last day in Scrumble might not be the day of the ceremony.
The function implemented in #255 now checks if the last day in Scrumble is a full day of code.

Case 1 : Ceremony is Friday at 9am
Team sets Thursday as the last day but Thursday is a full day of code.

Case 2 : Ceremony is Friday at 11am
Team sets Friday as the last day but Friday is not a full day (only 2hours of code).

###  Add VPTech + watcher role

When user is set as `watcher` for daily mail, she or he will receive the daily mails only if project is at risk.